### PR TITLE
Fix to allow verification of signed messages

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -28,7 +28,7 @@ var Message = function Message(message) {
   return this;
 };
 
-Message.MAGIC_BYTES = new Buffer('Bitcoin Signed Message:\n');
+Message.MAGIC_BYTES = new Buffer('Zcash Signed Message:\n');
 
 Message.prototype.magicHash = function magicHash() {
   var prefix1 = BufferWriter.varintBufNum(Message.MAGIC_BYTES.length);


### PR DESCRIPTION
This will need to be updated in the future if https://github.com/ZencashOfficial/zen/blob/4ba3514e1ecf3c13c4ffe2f902aeb3e006f01b54/src/main.cpp#L109 is updated from zcash to zen/horizen